### PR TITLE
Fix Playwright Download import

### DIFF
--- a/domo_export.ts
+++ b/domo_export.ts
@@ -1,7 +1,8 @@
 import "dotenv/config";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { chromium, Download } from "playwright";
+import { chromium } from "playwright";
+import type { Download } from "playwright";
 import * as XLSX from "xlsx";
 import { sendWithGmailAPI } from "./mailer_gmail.ts";
 


### PR DESCRIPTION
## Summary
- switch to a type-only import for Playwright's `Download` type to avoid runtime import errors

## Testing
- not run (requires DOMO credentials and environment)

------
https://chatgpt.com/codex/tasks/task_e_68dbcf87a94c832fa5cdea0f99ba6e98