### PR TITLE
Sanitize error logging to avoid leaking secrets

### DIFF
--- a/domo_export.ts
+++ b/domo_export.ts
@@ -33,6 +33,57 @@ if (!hasBasicSmtpCreds && !hasGoogleOAuthCreds) {
 
 const XLSXLib: typeof XLSX & { default?: typeof XLSX } = (XLSX as any).default ?? (XLSX as any);
 
+const SENSITIVE_ENV_KEYS = [
+    'DOMO_BASE_URL',
+    'DOMO_USERNAME',
+    'DOMO_PASSWORD',
+    'DOMO_VENDOR_ID',
+    'EMAIL_USER',
+    'EMAIL_PASS',
+    'EMAIL_HOST',
+    'EMAIL_PORT',
+    'EMAIL_TO',
+    'GOOGLE_CLIENT_ID',
+    'GOOGLE_CLIENT_SECRET',
+    'GOOGLE_REFRESH_TOKEN'
+] as const;
+
+const sensitiveEnvValues = SENSITIVE_ENV_KEYS
+    .map((key) => process.env[key])
+    .filter((value): value is string => Boolean(value));
+
+function maskSensitiveData(value: string): string {
+    return sensitiveEnvValues.reduce((masked, secret) => {
+        if (!secret) {
+            return masked;
+        }
+        return masked.split(secret).join('[REDACTED]');
+    }, value);
+}
+
+function sanitizeError(error: unknown): string {
+    if (error instanceof Error) {
+        if (error.stack) {
+            return maskSensitiveData(error.stack);
+        }
+        return maskSensitiveData(error.message);
+    }
+
+    if (typeof error === 'string') {
+        return maskSensitiveData(error);
+    }
+
+    try {
+        return maskSensitiveData(JSON.stringify(error));
+    } catch {
+        return 'Unknown error';
+    }
+}
+
+function logSanitizedError(context: string, error: unknown) {
+    console.error(`${context}: ${sanitizeError(error)}`);
+}
+
 function ensureDirectoryExists(filePath: string) {
     const directory = path.dirname(filePath);
     if (!fs.existsSync(directory)) {
@@ -64,7 +115,7 @@ async function getGmailAccessToken(): Promise<string> {
 
     if (!response.ok) {
         const errorBody = await response.text().catch(() => '<no body>');
-        throw new Error(`Failed to fetch Gmail access token: ${response.status} ${response.statusText} - ${errorBody}`);
+        throw new Error(`Failed to fetch Gmail access token: ${response.status} ${response.statusText} - ${maskSensitiveData(errorBody)}`);
     }
 
     const tokenPayload = await response.json();
@@ -227,11 +278,14 @@ async function main() {
         console.log(`Email sent to ${recipientCount} recipient(s).`);
 
     } catch (error) {
-        console.error('An error occurred:', error);
+        logSanitizedError('An error occurred', error);
         throw error;
     } finally {
         await browser.close();
     }
 }
 
-main().catch(console.error);
+main().catch((error) => {
+    logSanitizedError('Unhandled error in main', error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add utilities to mask sensitive environment variables before writing to logs
- sanitize Gmail token fetch errors and global error handlers to avoid exposing secrets

## Testing
- not run (requires environment credentials)

------
https://chatgpt.com/codex/tasks/task_e_68dbdfa090ec832f8993ed4311a43a58